### PR TITLE
Fix model directory issue in airflow tutorial

### DIFF
--- a/Labs/Airflow_Labs/Lab_1/dags/src/lab.py
+++ b/Labs/Airflow_Labs/Lab_1/dags/src/lab.py
@@ -59,13 +59,16 @@ def build_save_model(data, filename):
         kmeans.fit(df)
         sse.append(kmeans.inertia_)
     
-    output_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "model", filename)
+    output_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), "model")
+    # Create the model directory if it doesn't exist
+    os.makedirs(output_dir, exist_ok=True)
+    
+    output_path = os.path.join(output_dir, filename)
 
     # Save the trained model to a file
-    pickle.dump(kmeans, open(output_path, 'wb'))
-
+    with open(output_path, 'wb') as f:
+        pickle.dump(kmeans, f)
     return sse
-
 
 def load_model_elbow(filename,sse):
     """


### PR DESCRIPTION
The current tutorial/code does not ask to create a folder named model hence when the dag is run, it would crash.
Hence added directory creation to ensure the model can be saved successfully and help the other students who might work with the tutorial.